### PR TITLE
Enable Node.js built-in Type Stripping for direct TypeScript test execution

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,5 +26,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm run build --if-present
     - run: npm test

--- a/package.json
+++ b/package.json
@@ -44,13 +44,17 @@
   ],
   "scripts": {
     "example": "node --experimental-strip-types examples/run-async.mts",
+    "preversion": "npm run rebuild",
+    "rebuild": "npm run lint && npm run clean && npm run compile && npm run test:dist",
+    "clean": "rimraf dist",
+    "compile": "tsc",
     "typecheck": "tsc --noEmit",
-    "build": "rimraf dist && tsc",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "test:unit": "node --enable-source-maps --test \"./dist/__tests__/*test.mjs\"",
-    "test:doc": "node --enable-source-maps --test-reporter node-descmd-reporter --test \"./dist/__tests__/*test.mjs\"",
-    "test": "npm run lint && npm run build && npm run test:unit"
+    "test:dist": "node --enable-source-maps --test \"./dist/__tests__/*test.mjs\"",
+    "test:unit": "node --test \"./src/__tests__/*test.mts\"",
+    "test:doc": "node --test-reporter node-descmd-reporter --test \"./src/__tests__/*test.mts\"",
+    "test": "npm run lint && npm run test:unit"
   },
   "dependencies": {
     "benchmark": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "test:dist": "node --enable-source-maps --test \"./dist/__tests__/*test.mjs\"",
-    "test:unit": "node --test \"./src/__tests__/*test.mts\"",
-    "test:doc": "node --test-reporter node-descmd-reporter --test \"./src/__tests__/*test.mts\"",
+    "test:unit": "node --experimental-strip-types --test \"./src/__tests__/*test.mts\"",
+    "test:doc": "node --experimental-strip-types --test-reporter node-descmd-reporter --test \"./src/__tests__/*test.mts\"",
     "test": "npm run lint && npm run test:unit"
   },
   "dependencies": {

--- a/src/__tests__/async-benchmark-test.mts
+++ b/src/__tests__/async-benchmark-test.mts
@@ -1,4 +1,4 @@
-import { setupSuite, wrapPromiseBenchmark } from '../suite-setup.mjs';
+import { setupSuite, wrapPromiseBenchmark } from '../suite-setup.mts';
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import { tmpdir } from 'node:os';
 import { existsSync, rmSync } from 'node:fs';
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { strict as assert } from 'node:assert';
 import { EventEmitter } from 'node:events';
 import type { Suite as BenchmarkSuite, Options as BenchmarkOptions, Deferred } from 'benchmark';
-import type { NormalizedBenchmarkSpec, BenchmarkLogger } from '../suite-setup.mjs';
+import type { NormalizedBenchmarkSpec, BenchmarkLogger } from '../suite-setup.mts';
 
 const zf = (n: number, len = 2) => String(n).padStart(len, '0');
 const timestampString = (d = new Date()) => `${d.getFullYear()}${zf(d.getMonth() + 1)}${zf(d.getDate())}${zf(d.getHours())}${zf(d.getMinutes())}${zf(d.getSeconds())}${zf(d.getMilliseconds(), 3)}`;

--- a/src/__tests__/benchmark-diff-report-test.mts
+++ b/src/__tests__/benchmark-diff-report-test.mts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { logComparisonResult } from '../benchmark-diff.mjs';
+import { logComparisonResult } from '../benchmark-diff.mts';
 
 describe('logComparisonResult', () => {
   // Create a mock logger

--- a/src/__tests__/benchmark-diff-test.mts
+++ b/src/__tests__/benchmark-diff-test.mts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
 import Benchmark from 'benchmark';
-import { analyzePerformanceResults } from '../benchmark-diff.mjs';
+import { analyzePerformanceResults } from '../benchmark-diff.mts';
 
 describe('analyzePerformanceResults', () => {
   // Helper function is intentionally commented out as it's not used directly,

--- a/src/__tests__/blackhole-test.mts
+++ b/src/__tests__/blackhole-test.mts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { blackhole } from '../suite-setup.mjs';
+import { blackhole } from '../suite-setup.mts';
 
 test('blackhole function should not throw any errors', () => {
   // Check that blackhole accepts various value types without throwing errors

--- a/src/__tests__/suite-setup-test.mts
+++ b/src/__tests__/suite-setup-test.mts
@@ -1,4 +1,4 @@
-import { setupSuite, normalizeSpecs, benchmarkName } from '../suite-setup.mjs';
+import { setupSuite, normalizeSpecs, benchmarkName } from '../suite-setup.mts';
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import { tmpdir } from 'node:os';
 import { existsSync, rmSync } from 'node:fs';
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { strict as assert } from 'node:assert';
 import { EventEmitter } from 'node:events';
 import type { Suite as BenchmarkSuite, Options as BenchmarkOptions } from 'benchmark';
-import type { NormalizedBenchmarkSpec } from '../suite-setup.mjs';
+import type { NormalizedBenchmarkSpec } from '../suite-setup.mts';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const zf = (n: number, len = 2) => String(n).padStart(len, '0');

--- a/src/__tests__/task-parser-test.mts
+++ b/src/__tests__/task-parser-test.mts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { parseCommandLine } from '../suite-setup.mjs';
+import { parseCommandLine } from '../suite-setup.mts';
 
 describe('parseCommandLine', () => {
   it('./setup.sh', () => {

--- a/src/__tests__/test.mts
+++ b/src/__tests__/test.mts
@@ -1,4 +1,4 @@
-import { runBenchmark } from '../index.mjs';
+import { runBenchmark } from '../index.mts';
 import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { createRequire } from 'node:module';

--- a/src/benchmark-diff.mts
+++ b/src/benchmark-diff.mts
@@ -1,7 +1,7 @@
 import type Benchmark from 'benchmark';
-import { runBenchmark } from './run-benchmark.mjs';
-import { ConsoleLogger } from './suite-setup.mjs';
-import type { BenchmarkRegisterFunction, BenchmarkTarget, BenchmarkLogger } from './suite-setup.mjs';
+import { runBenchmark } from './run-benchmark.mts';
+import { ConsoleLogger } from './suite-setup.mts';
+import type { BenchmarkRegisterFunction, BenchmarkTarget, BenchmarkLogger } from './suite-setup.mts';
 
 /**
  * Specification for the baseline branch to compare against

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,5 +1,5 @@
-export { benchmarkDiffWithBaseline } from './benchmark-diff.mjs';
-export { runBenchmark } from './run-benchmark.mjs';
+export { benchmarkDiffWithBaseline } from './benchmark-diff.mts';
+export { runBenchmark } from './run-benchmark.mts';
 export type {
   BenchmarkSpec,
   NormalizedBenchmarkSpec,
@@ -12,13 +12,13 @@ export type {
   AsyncBenchmarkRegistration,
   BenchmarkRegistration,
   BenchmarkLogger
-} from './suite-setup.mjs';
+} from './suite-setup.mts';
 export type {
   BaselineSpec,
   ComparisonOptions,
   AnalysisResult,
   AnalysisFailure
-} from './benchmark-diff.mjs';
+} from './benchmark-diff.mts';
 export type {
   BenchmarkOptions
-} from './run-benchmark.mjs';
+} from './run-benchmark.mts';

--- a/src/run-benchmark.mts
+++ b/src/run-benchmark.mts
@@ -1,13 +1,13 @@
 import { join } from 'node:path';
 import { rmSync } from 'node:fs';
 import Benchmark from 'benchmark';
-import { setupSuite, normalizeSpecs, benchmarkName, ConsoleLogger } from './suite-setup.mjs';
+import { setupSuite, normalizeSpecs, benchmarkName, ConsoleLogger } from './suite-setup.mts';
 import type {
   NormalizedBenchmarkSpec,
   BenchmarkRegisterFunction,
   BenchmarkTarget,
   BenchmarkLogger
-} from './suite-setup.mjs';
+} from './suite-setup.mts';
 
 /**
  * Event triggered when a benchmark is aborted

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
     // any imports or exports without a type modifier are left around
     "verbatimModuleSyntax": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Summary

Enable Node.js built-in Type Stripping feature to run tests directly from TypeScript source files, eliminating the need to compile TypeScript before running tests during development.

## Changes

### TypeScript Configuration
- **Enable `rewriteRelativeImportExtensions`**: Automatically rewrites `.mts` imports to `.mjs` for compatibility
- **Enable `erasableSyntaxOnly`**: Ensures only syntax that can be safely erased is used, making code compatible with Node.js type stripping

### Import Path Updates
- Updated all internal imports from `.mjs` to `.mts` extensions in source files
- Affects all test files and source modules for consistency

### npm Scripts Restructuring
- **Changed test execution**: `test:unit` now runs directly from TypeScript source (`./src/__tests__/*test.mts`)
- **Separated concerns**: 
  - `test:unit`: Direct TypeScript execution for development
  - `test:dist`: Compiled JavaScript execution for distribution validation
- **Simplified main test command**: `npm test` no longer requires compilation step
- **Added rebuild workflow**: `npm run rebuild` for full compilation and distribution testing

### CI/CD Optimization
- Removed `npm run build` step from GitHub Actions workflow
- Tests now run directly from source, reducing CI execution time

## Benefits

1. **Faster development cycle**: No compilation step needed for running tests
2. **Simplified workflow**: Direct TypeScript execution during development
3. **Maintained compatibility**: Distribution still uses compiled JavaScript
4. **Reduced CI time**: Elimination of build step in continuous integration

## Test Plan

- [x] Verify `npm test` runs successfully with new configuration
- [x] Confirm `npm run test:unit` executes TypeScript files directly
- [x] Ensure `npm run test:dist` still works with compiled files
- [x] Validate CI workflow runs without build step
- [x] Check that all import paths resolve correctly

🤖 Generated with [Claude Code](https://claude.ai/code)